### PR TITLE
fixes #16 - SSLHandshakeException / SSLProtocolException: handshake aborted: Failure in SSL library, usually a protocol error (Android 4)

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/CustomHttpClient.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/CustomHttpClient.java
@@ -1,6 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.net;
 
 import android.app.Activity;
+import android.os.Build;
 import android.widget.Toast;
 
 import java.security.KeyManagementException;
@@ -49,8 +50,14 @@ public class CustomHttpClient {
             httpLoggingInterceptor.setLevel(Level.HEADERS);
             clientBuilder.addNetworkInterceptor(httpLoggingInterceptor);
         }
+
         X509TrustManager trustManager = TrustManagerFactory.get(host, true);
-        clientBuilder.sslSocketFactory(createSSLSocketFactory(trustManager), trustManager);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            clientBuilder.sslSocketFactory(new TLSSocketFactory(), trustManager);
+        } else {
+            clientBuilder.sslSocketFactory(createSSLSocketFactory(trustManager), trustManager);
+        }
+
         return clientBuilder.build();
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/TLSSocketFactory.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/TLSSocketFactory.java
@@ -1,0 +1,69 @@
+package nerd.tuxmobil.fahrplan.congress.net;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+public class TLSSocketFactory extends SSLSocketFactory {
+
+    private SSLSocketFactory internalSSLSocketFactory;
+
+    TLSSocketFactory() throws KeyManagementException, NoSuchAlgorithmException {
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, null, null);
+        internalSSLSocketFactory = context.getSocketFactory();
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return internalSSLSocketFactory.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return internalSSLSocketFactory.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket() throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket());
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket enableTLSOnSocket(Socket socket) {
+        if (socket != null && (socket instanceof SSLSocket)) {
+            ((SSLSocket) socket).setEnabledProtocols(new String[]{"TLSv1.1", "TLSv1.2"});
+        }
+        return socket;
+    }
+}


### PR DESCRIPTION
This solves issue #16. The problem has to do with TLS 1.1 and 1.2 being available on Android 4.1 up to 4.4, but in those versions it is usually deactivated by default.

Most credits go to this [blog post](https://blog.dev-area.net/2015/08/13/android-4-1-enable-tls-1-1-and-tls-1-2/).