### PR TITLE
use the url-field whenever it is available

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposer.kt
@@ -17,10 +17,10 @@ class EventUrlComposer @JvmOverloads constructor(
         return event.eventUrl
     }
 
-    private val Event.eventUrl get() {
+    private val Event.eventUrl: String get() {
             when (serverBackEndType) {
-                    PENTABARF.name -> getComposedEventUrl(event.slug)
-                    else -> if (url == null || url.isEmpty()) getComposedEventUrl(lecture_id) else url
+                    PENTABARF.name -> return getComposedEventUrl(event.slug)
+                    else -> if (url == null || url.isEmpty()) return getComposedEventUrl(lecture_id) else return url
             }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposer.kt
@@ -13,12 +13,16 @@ class EventUrlComposer @JvmOverloads constructor(
 
 ) {
 
-    fun getEventUrl(): String{
+    fun getEventUrl(): String {
         return event.eventUrl
     }
 
-    private val Event.eventUrl
-        get() = if (url == null || url.isEmpty()) getComposedEventUrl(lecture_id) else url
+    private val Event.eventUrl get() {
+            when (serverBackEndType) {
+                    PENTABARF.name -> getComposedEventUrl(event.slug)
+                    else -> if (url == null || url.isEmpty()) getComposedEventUrl(lecture_id) else url
+            }
+    }
 
     private fun getComposedEventUrl(eventIdentifier: String) =
             String.format(eventUrlTemplate, eventIdentifier)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposer.kt
@@ -13,15 +13,12 @@ class EventUrlComposer @JvmOverloads constructor(
 
 ) {
 
-    fun getEventUrl(): String = when (serverBackEndType) {
-        PENTABARF.name -> getComposedEventUrl(event.slug)
-        FRAB.name -> event.eventUrl
-        PRETALX.name -> event.url
-        else -> throw NotImplementedError("Unknown server backend type: '$serverBackEndType'")
+    fun getEventUrl(): String{
+        return event.eventUrl
     }
 
     private val Event.eventUrl
-        get() = if (originatesFromPretalx) url else getComposedEventUrl(lecture_id)
+        get() = if (url == null || url.isEmpty()) getComposedEventUrl(lecture_id) else url
 
     private fun getComposedEventUrl(eventIdentifier: String) =
             String.format(eventUrlTemplate, eventIdentifier)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposerTest.kt
@@ -9,7 +9,7 @@ class EventUrlComposerTest {
     companion object {
 
         private const val FRAB_EVENT_URL_TEMPLATE =
-                "https://events.ccc.de/congress/2018/Fahrplan/events/%1\$s.html"
+                "https://fahrplan.events.ccc.de/congress/2018/Fahrplan/events/%1\$s.html"
 
         private const val PENTABARF_EVENT_URL_TEMPLATE =
                 "https://fosdem.org/2018/schedule/event/%1\$s/"
@@ -49,7 +49,7 @@ class EventUrlComposerTest {
     @Test
     fun getEventUrlWithFrabEventWithFrabBackend() {
         assertThat(EventUrlComposer(FRAB_EVENT, FRAB_EVENT_URL_TEMPLATE, ServerBackendType.FRAB.name)
-                .getEventUrl()).isEqualTo("https://events.ccc.de/congress/2018/Fahrplan/events/9985.html")
+                .getEventUrl()).isEqualTo("https://fahrplan.events.ccc.de/congress/2018/Fahrplan/events/9985.html")
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposerTest.kt
@@ -9,7 +9,7 @@ class EventUrlComposerTest {
     companion object {
 
         private const val FRAB_EVENT_URL_TEMPLATE =
-                "https://events.ccc.de/congress/2017/Fahrplan/events/%1\$s.html"
+                "https://events.ccc.de/congress/2018/Fahrplan/events/%1\$s.html"
 
         private const val PENTABARF_EVENT_URL_TEMPLATE =
                 "https://fosdem.org/2018/schedule/event/%1\$s/"
@@ -49,7 +49,7 @@ class EventUrlComposerTest {
     @Test
     fun getEventUrlWithFrabEventWithFrabBackend() {
         assertThat(EventUrlComposer(FRAB_EVENT, FRAB_EVENT_URL_TEMPLATE, ServerBackendType.FRAB.name)
-                .getEventUrl()).isEqualTo("https://events.ccc.de/congress/2017/Fahrplan/events/9985.html")
+                .getEventUrl()).isEqualTo("https://events.ccc.de/congress/2018/Fahrplan/events/9985.html")
     }
 
     @Test

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -15,7 +15,7 @@ object GradlePlugins {
 
     private object Versions {
         const val androidGradle = "3.4.2"
-        const val gradleVersions = "0.21.0"
+        const val gradleVersions = "0.22.0"
         const val sonarQubeGradle = "2.7.1"
     }
 


### PR DESCRIPTION
only generate it, when it is not provided.
this closes EventFahrplan/EventFahrplan#150 
I've also modified the tests because I think there is no reason that the composed url should be preferred over the original stated one.